### PR TITLE
fixed warnings when doing filemtime on file before checking if it exi…

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -23,14 +23,14 @@
     =================================================== */
     // Use the sitepath if it's defined
     if (defined('PERCH_SITEPATH')) {
-        if (file_exists("{$_SERVER['DOCUMENT_ROOT']}" . PERCH_SITEPATH . "perch/addons/plugins/ui/custom-admin.css")) {
-            $custom_admin_version = PERCH_SITEPATH . 'perch/addons/plugins/ui/custom-admin.css?v=' . filemtime($_SERVER['DOCUMENT_ROOT'] . '/perch/addons/plugins/ui/custom-admin.css');
+        if (file_exists("{$_SERVER['DOCUMENT_ROOT']}" . PERCH_SITEPATH . PERCH_LOGINPATH ."/addons/plugins/ui/custom-admin.css")) {
+            $custom_admin_version = PERCH_SITEPATH . PERCH_LOGINPATH .'/addons/plugins/ui/custom-admin.css?v=' . filemtime($_SERVER['DOCUMENT_ROOT'] . '/'.PERCH_LOGINPATH.'/addons/plugins/ui/custom-admin.css');
             $Perch->add_css($custom_admin_version);
         }
     } else {
         // Otherwise assume its the document root
-        if (file_exists("{$_SERVER['DOCUMENT_ROOT']}/perch/addons/plugins/ui/custom-admin.css")) {
-            $custom_admin_version = '/perch/addons/plugins/ui/custom-admin.css?v=' . filemtime($_SERVER['DOCUMENT_ROOT'] . '/perch/addons/plugins/ui/custom-admin.css');
+        if (file_exists("{$_SERVER['DOCUMENT_ROOT']}".PERCH_LOGINPATH. "/addons/plugins/ui/custom-admin.css")) {
+            $custom_admin_version = PERCH_LOGINPATH . '/addons/plugins/ui/custom-admin.css?v=' . filemtime($_SERVER['DOCUMENT_ROOT'] . PERCH_LOGINPATH.'/addons/plugins/ui/custom-admin.css');
             $Perch->add_css($custom_admin_version);
         }
     }
@@ -40,14 +40,12 @@
     =================================================== */
     // Use the sitepath if it's defined
     if (defined('PERCH_SITEPATH')) {
-        $favicon_version = '<link rel="shortcut icon" href="' . PERCH_SITEPATH . 'perch/addons/plugins/ui/favicon.ico?v=' . filemtime($_SERVER['DOCUMENT_ROOT'] . '/perch/addons/plugins/ui/favicon.ico') . '">';
-        if (file_exists("{$_SERVER['DOCUMENT_ROOT']}" . PERCH_SITEPATH . "perch/addons/plugins/ui/favicon.ico")) {
-            $Perch->add_head_content($favicon_version);
+        if (file_exists("{$_SERVER['DOCUMENT_ROOT']}" . PERCH_SITEPATH . PERCH_LOGINPATH. "/addons/plugins/ui/favicon.ico")) {
+            $Perch->add_head_content('<link rel="shortcut icon" href="' . PERCH_SITEPATH . PERCH_LOGINPATH.'/addons/plugins/ui/favicon.ico?v=' . filemtime($_SERVER['DOCUMENT_ROOT'] .  PERCH_LOGINPATH.'/addons/plugins/ui/favicon.ico') . '">');
         }
     } else {
         // Otherwise assume its the document root
-        $favicon_version = '<link rel="shortcut icon" href="/perch/addons/plugins/ui/favicon.ico?v=' . filemtime($_SERVER['DOCUMENT_ROOT'] . '/perch/addons/plugins/ui/favicon.ico') . '">';
-        if (file_exists("{$_SERVER['DOCUMENT_ROOT']}/perch/addons/plugins/ui/favicon.ico")) {
-            $Perch->add_head_content($favicon_version);
+        if (file_exists("{$_SERVER['DOCUMENT_ROOT']}" . PERCH_LOGINPATH . "/addons/plugins/ui/favicon.ico")) {
+            $Perch->add_head_content('<link rel="shortcut icon" href="'.PERCH_LOGINPATH.'/addons/plugins/ui/favicon.ico?v=' . filemtime($_SERVER['DOCUMENT_ROOT'] .  PERCH_LOGINPATH.'/addons/plugins/ui/favicon.ico') . '">');
         }
     }

--- a/modes/list.post.php
+++ b/modes/list.post.php
@@ -15,40 +15,40 @@
     echo $HTML->heading1('About the Admin Style app');
 
     // if (isset($message)) echo $message;
-    echo '<p>The <em>Admin Style</em> app styles the Perch admin.<br><strong>All settings for Admin Style are stored in <a href="/perch/core/settings#jaygeorge_perch_admin_style">Settings</a></strong>.</p><p>It&apos;s been tested in the latest versions of Chrome, Safari, Firefox, and Microsoft Edge. It mostly just needs browsers that support CSS variables, which are used extensively in the app.</p><p>This app was developed by Jay George.</p>';
+    echo '<p>The <em>Admin Style</em> app styles the Perch admin.<br><strong>All settings for Admin Style are stored in <a href="/'.PERCH_LOGINPATH.'/core/settings#jaygeorge_perch_admin_style">Settings</a></strong>.</p><p>It&apos;s been tested in the latest versions of Chrome, Safari, Firefox, and Microsoft Edge. It mostly just needs browsers that support CSS variables, which are used extensively in the app.</p><p>This app was developed by Jay George.</p>';
 
     echo $HTML->heading1('Instructions');
 
     echo '
     <ol>
         <li>
-            <strong>Go to <a href="/perch/core/settings">Settings</a>.</strong> This app assummes a few settings are ticked.</code>
+            <strong>Go to <a href="'.PERCH_LOGINPATH.'/core/settings">Settings</a>.</strong> This app assummes a few settings are ticked.</code>
             <ul>
                 <li>Tick "Show dedicated back link in sidebar"</li>
                 <li>Tick "Hide Perch Branding"</li>
             </ul>
         </li>
         <li>
-            <strong>Copy the starter files</strong> in <code>/perch/addons/apps/jaygeorge_perch_admin_style/extra/</code> paste them into <code>/perch/addons/plugins/ui</code>
+            <strong>Copy the starter files</strong> in <code>/'.PERCH_LOGINPATH.'/addons/apps/jaygeorge_perch_admin_style/extra/</code> paste them into <code>/'.PERCH_LOGINPATH.'/addons/plugins/ui</code>
         </li>
         <li>
-            <strong>Add any client-specific admin styling</strong>. You should now use <code>/perch/addons/plugins/ui/custom-admin.css</code> to add client-specific CSS to brand the admin. You may just want to change the variable values.
+            <strong>Add any client-specific admin styling</strong>. You should now use <code>/'.PERCH_LOGINPATH.'/addons/plugins/ui/custom-admin.css</code> to add client-specific CSS to brand the admin. You may just want to change the variable values.
         </li>
         <li>
-            <strong>Add your logo</strong> as <code>/perch/addons/plugins/ui/logo-dark.svg</code>. You should also add a logo that can be used on a white background (for the mobile admin view) as <code>/perch/addons/plugins/ui/logo.svg</code>. It should be a square SVG to ensure the admin works well responsively. Using the site favicon works great.
+            <strong>Add your logo</strong> as <code>/'.PERCH_LOGINPATH.'/addons/plugins/ui/logo-dark.svg</code>. You should also add a logo that can be used on a white background (for the mobile admin view) as <code>/'.PERCH_LOGINPATH.'/addons/plugins/ui/logo.svg</code>. It should be a square SVG to ensure the admin works well responsively. Using the site favicon works great.
         </li>
         <li>
-            <strong>Add your favicon</strong> as <code>/perch/addons/plugins/ui/favicon.ico</code>
+            <strong>Add your favicon</strong> as <code>/'.PERCH_LOGINPATH.'/addons/plugins/ui/favicon.ico</code>
         </li>
         <li>
-            <strong>Go through the app <a href="/perch/core/settings#jaygeorge_perch_admin_style">settings</a></strong> page to add extra things like external font stylesheets.
+            <strong>Go through the app <a href="/'.PERCH_LOGINPATH.'/core/settings#jaygeorge_perch_admin_style">settings</a></strong> page to add extra things like external font stylesheets.
         </li>
     </ol>';
 
     echo $HTML->heading1('Notes');
-    echo '<p>This app contains base styling. To future proof as much as possible this app tries not to touch any layout; only padding and colouring adjustments. Do <em>not</em> change the values of any file in the plugin folder—instead use your new <code>/perch/addons/plugins/ui/custom-admin.css</code> to style the admin.</p>
+    echo '<p>This app contains base styling. To future proof as much as possible this app tries not to touch any layout; only padding and colouring adjustments. Do <em>not</em> change the values of any file in the plugin folder—instead use your new <code>/'.PERCH_LOGINPATH.'/addons/plugins/ui/custom-admin.css</code> to style the admin.</p>
 
-    <p><sub>v. ' . date('Y-m-d H:i:s',filemtime($_SERVER['DOCUMENT_ROOT'].'/perch/addons/apps/jaygeorge_perch_admin_style')) . '</sub></p>';
+    <p><sub>v. ' . date('Y-m-d H:i:s',filemtime($_SERVER['DOCUMENT_ROOT'].'/'. PERCH_LOGINPATH . '/addons/apps/jaygeorge_perch_admin_style')) . '</sub></p>';
 
     if (PerchUtil::count($things)) {
 

--- a/standard-admin.css
+++ b/standard-admin.css
@@ -271,14 +271,14 @@ header .sidebar-back a:focus {
     .topbar.runway.user_theme_light.nobrand,
     .topbar.user_theme_dark.nobrand,
     .topbar.user_theme_light.nobrand {
-        background-image: url(/perch/addons/plugins/ui/logo-dark.svg);
+        background-image: url(../../plugins/ui/logo-dark.svg);
         background-size: 50px;
         background-position: center center;
     }
 
     .topbar.runway.user_theme_light.nobrand,
     .topbar.user_theme_light.nobrand {
-        background-image: url(/perch/addons/plugins/ui/logo.svg);
+        background-image: url(../../plugins/ui/logo.svg);
     }
 }
 
@@ -396,7 +396,7 @@ header .sidebar-back a:focus {
 /* --mq-before-mobile-layout */
 @media (max-width: 549px) {
     .sidebar {
-        background-image: url(/perch/addons/plugins/ui/logo.svg);
+        background-image: url(../../plugins/ui/logo.svg);
         background-size: 50px 75px;
         background-position: bottom right 15px;
     }


### PR DESCRIPTION
Hi Jay, 

Love your theme, noticed a couple of things and though I'd maybe help out.  This pull request does a couple of things:

1. Fixes a warning when doing the `filemtime` on the favicon before checking if it exists. Warning was thrown because icon didin't exits.  No it does the `filemtime` after checking it exists.
2. Removes the assumption that perch is installed in the `/perch` directory.  It can now be added to any directory like `/admin`