### PR TITLE
Add optional css sheet by role

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -24,9 +24,17 @@ if (file_exists(__DIR__ . "/../../plugins/ui/custom-admin.css")) {
 
 $Perch->add_css($API->get('Settings')->get('jaygeorge_perch_admin_style_external_font_stylesheet')->val());
 
+/* LOAD CSS FOR ROLE
+=================================================== */
+$role = $CurrentUser->roleSlug();
+if (file_exists(__DIR__ . '/../../plugins/ui/custom-admin-' . $role . '.css')) {
+    $Perch->add_css(PERCH_LOGINPATH .'/addons/plugins/ui/custom-admin-' . $role . '.css?v=' . filemtime(__DIR__ . '/../../plugins/ui/custom-admin-' . $role . '.css'));
+}
+
 /* GROUP LOAD THE FAVICON
 =================================================== */
 
 if (file_exists(__DIR__ . "/../../plugins/ui/favicon.ico")) {
     $Perch->add_head_content('<link rel="shortcut icon" href="' . PERCH_LOGINPATH.'/addons/plugins/ui/favicon.ico?v=' . filemtime(__DIR__ . '/../../plugins/ui/favicon.ico') . '">');
 }
+


### PR DESCRIPTION
We can change what menu items are available by the users role by adjusting the `perch3_menu_items.privID` column in the DB.  But doing so this changes links available in the sidebar menu messing up any custom admin icons that are applied to all roles.

With this pull request, we can create role specific css sheets that will override the default custom admin css as needed so we can keep the icons consistent across roles.

You simply need to create a css file in `/perch/addons/plugins/ui/custom-admin-[roleSlug].css` where the [roleSlug] matches the corresponding role in `perch3_user_roles.roleSlug` DB column